### PR TITLE
chore: lock release version to 0.1.0

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -7,7 +7,8 @@
             "bump-minor-pre-major": true,
             "separate-pull-requests": true,
             "include-component-in-tag": true,
-            "include-v-in-tag": true
+            "include-v-in-tag": true,
+            "release-as": "0.1.0"
         }
     },
     "release-search-depth": 100,


### PR DESCRIPTION
lock release version to 0.1.0