### PR TITLE
fix: platform optional health check

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -198,6 +198,7 @@ grpcurl -insecure $PLATFORM_HOST:443 kas.AccessService/PublicKey
 | server.port | int | `9000` | The server port |
 | server.tls.enabled | bool | `true` | Enables tls |
 | server.tls.secret | string | `nil` | The server tls certificate. If not set, a self-signed certificate is generated |
+| server.healthCheckz | bool | `true` | Enables liveness and readiness probe health check to server |
 | service.port | int | `9000` | The port of the service |
 | service.type | string | `"ClusterIP"` | The type of service to create |
 | serviceAccount.annotations | object | `{}` | Extra annotations to add to the service account |

--- a/charts/platform/templates/deployment.yaml
+++ b/charts/platform/templates/deployment.yaml
@@ -46,6 +46,7 @@ spec:
             - name: http
               containerPort: {{ .Values.server.port }}
               protocol: TCP
+          {{ if .Values.server.healthCheckz }}
           livenessProbe:
             httpGet:
               scheme: {{ if .Values.server.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}              
@@ -56,6 +57,7 @@ spec:
               scheme: {{ if .Values.server.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
               path: /healthz?service=readiness
               port: http
+          {{ end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -158,6 +158,8 @@ server:
   grpc:
     # -- Enables grpc reflection (https://github.com/grpc/grpc/blob/master/doc/server-reflection.md)
     reflectionEnabled: true
+  # -- Enables Kubernetes Health Checkz
+  healthCheckz: true
   tls:
     # -- Enables tls
     enabled: true


### PR DESCRIPTION
Platform has a bug that crashes on health check i.e.
```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1366730]

goroutine 231 [running]:
github.com/opentdf/platform/service/health.HealthService.Check({{}, 0x0?}, {0x1aa2ef0?, 0x4000326ae0?}, 0x400050ea38?)
	/app/service/health/health.go:51 +0x80
google.golang.org/grpc/health/grpc_health_v1._Health_Check_Handler({0x1536e60, 0x400054a0f8}, {0x1aa2ef0, 0x4000326ae0}, 0x4000144e00, 0x0)
	/root/go/pkg/mod/google.golang.org/grpc@v1.63.2/health/grpc_health_v1/health_grpc.pb.go:184 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x4000035600, {0x1aa2ef0, 0x40003269f0}, {0x1aae4c0, 0x40002c0180}, 0x400011f440, 0x4000256540, 0x260b800, 0x0)
	/root/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1369 +0xb58
google.golang.org/grpc.(*Server).handleStream(0x4000035600, {0x1aae4c0, 0x40002c0180}, 0x400011f440)
	/root/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1780 +0xb20
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/root/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1019 +0x8c
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 214
	/root/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1030 +0x13c
```
	
This PR makes health check optional probing so it does not crash on health check.

