### PR TITLE
fix: changes service to http2 from http

### DIFF
--- a/charts/platform/templates/deployment.yaml
+++ b/charts/platform/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: http
+            - name: http2
               containerPort: {{ .Values.server.port }}
               protocol: TCP
           {{ if .Values.server.healthCheckz }}
@@ -51,12 +51,12 @@ spec:
             httpGet:
               scheme: {{ if .Values.server.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}              
               path: /healthz?service=liveness
-              port: http
+              port: http2
           readinessProbe:
             httpGet:
               scheme: {{ if .Values.server.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
               path: /healthz?service=readiness
-              port: http
+              port: http2
           {{ end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/platform/templates/service.yaml
+++ b/charts/platform/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: http2
       protocol: TCP
       name: http2
   selector:

--- a/charts/platform/templates/service.yaml
+++ b/charts/platform/templates/service.yaml
@@ -10,6 +10,6 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
-      name: http
+      name: http2
   selector:
     {{- include "chart.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
If Service Protocol is used as HTTP rather than HTTP2, the GRPC will fail. Since, Platform is a gRPC service, it is best we use HTTP2.

I ran into this by setting up a Istio Ingress Gateway, and the gRPC call will just end up hanging until the context deadline kills it. Switching the Service to HTTP2 or GRPC fixed it.
