### PR TITLE
docs: make use of 'nightly' image for playground config

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -80,10 +80,16 @@ ingress:
 
 ### Playground Configuration (Optional)
 
-If you want to test the platform quickly without having to worry about setting up a database and identity provider, you can use the following configuration:
+If you want to test the platform quickly without having to worry about setting up a database and identity provider, you can use the following configuration.
+
+NOTE: Currently, this Playground configuration uses the unstable "nightly" image as as the default.  In the future, expect this to be a pinned version:
 
 ```yaml
 playground: true # Enable playground mode
+
+image:
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: "nightly"
 
 # Only need to configure keycloak ingress and adminIngress
 keycloak:


### PR DESCRIPTION
Just an idea, interested to see where the conversation leads 🙂 

I also wonder, as a non-k8s guru, would it be reasonable to just set the value in `charts/charts/platform/Chart.yaml` to `nightly`? 

https://github.com/opentdf/charts/blob/9b9c0db7cab6cbacf826c40165b4248fbec858bf/charts/platform/Chart.yaml#L20-L24

Fixes #35 