### PR TITLE
fix: remove container command

### DIFF
--- a/charts/platform/templates/deployment.yaml
+++ b/charts/platform/templates/deployment.yaml
@@ -32,8 +32,6 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          command:
-            - opentdf
           args:
             - start
             - --config-file


### PR DESCRIPTION
Setting the command to `opentdf` is not needed after fixing the image entrypoint