### PR TITLE
feat: add entity resolution service to values

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -330,6 +330,10 @@ realms:
 | services.kas.enabled | bool | `true` | KAS service enabled |
 | services.kas.privateKeysSecret | string | `"kas-private-keys"` | KAS secret containing keys kas-private.pem , kas-cert.pem , kas-ec-private.pem , kas-ec-cert.pem |
 | services.entityresolution.enabled | bool | `false` | Entity Resolution service enabled |
+| services.entityresolution.url | string | `""` | Identity Provider Entity Resolver |
+| services.entityresolution.clientid | string | `tdf-entity-resolution` | Client Id for Entity Resolver |
+| services.entityresolution.clientsecret | string | `""` | Client Secret for Entity Resolver |
+| services.entityresolution.realm | string | `"opentdf"` | Entity Resolver Realm |
 | tolerations | list | `[]` | Tolerations to apply to the pod (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
 | volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |
 | volumes | list | `[]` | Additional volumes on the output Deployment definition. |

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -329,6 +329,7 @@ realms:
 | services.authorization.url | string | `nil` | External entity store (currently only keycloak is supported) |
 | services.kas.enabled | bool | `true` | KAS service enabled |
 | services.kas.privateKeysSecret | string | `"kas-private-keys"` | KAS secret containing keys kas-private.pem , kas-cert.pem , kas-ec-private.pem , kas-ec-cert.pem |
+| services.entityresolution.enabled | bool | `false` | Entity Resolution service enabled |
 | tolerations | list | `[]` | Tolerations to apply to the pod (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
 | volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |
 | volumes | list | `[]` | Additional volumes on the output Deployment definition. |

--- a/charts/platform/templates/config.yaml
+++ b/charts/platform/templates/config.yaml
@@ -12,6 +12,8 @@ data:
     {{- omit .Values.db "password" | toYaml | nindent 6 }}
       password: # loaded from env
     services:
+      entityresolution: 
+        {{- .Values.services.entityresolution | toYaml | nindent 8 }}
       kas:
         enabled: {{ .Values.services.kas.enabled }}
       authorization:

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -199,6 +199,8 @@ server:
           privateKeyPath: /etc/opentdf/kas/kas-ec-private.pem
           publicKeyPath: /etc/opentdf/kas/kas-ec-cert.pem
 services:
+  entityresolution:
+    enabled: false
   kas:
     # -- KAS service enabled
     enabled: true

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -200,7 +200,17 @@ server:
           publicKeyPath: /etc/opentdf/kas/kas-ec-cert.pem
 services:
   entityresolution:
+    # -- Entity Resolver service enabled
     enabled: false
+    # -- Identity Provider Entity Resolver
+    url:
+    # -- Client Id for Entity Resolver 
+    clientid: tdf-entity-resolution
+    # -- Client Secret for Entity Resolver
+    clientsecret:
+    # -- Entity Resolver Realm 
+    realm: opentdf
+
   kas:
     # -- KAS service enabled
     enabled: true


### PR DESCRIPTION
Adds the entity resolution to services available in values and add its to the platform configmap.

Updates README to default enabled false.
