### PR TITLE
fix(platform): update kas key paths to new config format

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -1,6 +1,6 @@
 # platform
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: nightly](https://img.shields.io/badge/AppVersion-nightly-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: nightly](https://img.shields.io/badge/AppVersion-nightly-informational?style=flat-square)
 
 A Helm Chart for OpenTDF Platform
 
@@ -305,10 +305,10 @@ realms:
 | server.auth.policy.csv | string | `nil` |  |
 | server.auth.policy.default | string | `nil` |  |
 | server.auth.policy.map | string | `nil` |  |
-| server.cryptoProvider.standard.ec.key1.privateKeyPath | string | `"/etc/platform/kas/kas-ec-private.pem"` |  |
-| server.cryptoProvider.standard.ec.key1.publicKeyPath | string | `"/etc/platform/kas/kas-ec-cert.pem"` |  |
-| server.cryptoProvider.standard.rsa.key1.privateKeyPath | string | `"/etc/platform/kas/kas-private.pem"` |  |
-| server.cryptoProvider.standard.rsa.key1.publicKeyPath | string | `"/etc/platform/kas/kas-cert.pem"` |  |
+| server.cryptoProvider.standard.ec.key1.private_key_path | string | `"/etc/platform/kas/kas-ec-private.pem"` |  |
+| server.cryptoProvider.standard.ec.key1.public_key_path | string | `"/etc/platform/kas/kas-ec-cert.pem"` |  |
+| server.cryptoProvider.standard.rsa.key1.private_key_path | string | `"/etc/platform/kas/kas-private.pem"` |  |
+| server.cryptoProvider.standard.rsa.key1.public_key_path | string | `"/etc/platform/kas/kas-cert.pem"` |  |
 | server.disableHealthChecks | bool | `false` | Disable Kubernetes Health Checks. (Useful for debugging) |
 | server.grpc.reflectionEnabled | bool | `true` | Enables grpc reflection (https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) |
 | server.port | int | `9000` | The server port |

--- a/charts/platform/templates/config.yaml
+++ b/charts/platform/templates/config.yaml
@@ -5,25 +5,25 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
 data:
- {{ include "platform.configFileName" .}}: |-
+ {{ include "platform.configFileName" . }}: |
     logger: 
-    {{- .Values.logger | toYaml | nindent 6 }}
+      {{- .Values.logger | toYaml | nindent 6 }}
     db:
-    {{- omit .Values.db "password" | toYaml | nindent 6 }}
+      {{- omit .Values.db "password" | toYaml | nindent 6 }}
       password: # loaded from env
     services:
       entityresolution: 
         {{- .Values.services.entityresolution | toYaml | nindent 8 }}
       kas:
-        enabled: {{ .Values.services.kas.enabled }}
+        enabled: {{ .Values.services.kas.enabled | quote }}
       authorization:
         {{- .Values.services.authorization | toYaml | nindent 8 }}
     server:
-      port: {{ .Values.server.port }}
+      port: {{ .Values.server.port | quote }}
       grpc:
-        reflectionEnabled: {{ .Values.server.grpc.reflectionEnabled }} # Default is false
+        reflectionEnabled: {{ .Values.server.grpc.reflectionEnabled | quote }} # Default is false
       tls:
-        enabled: {{ .Values.server.tls.enabled }}
+        enabled: {{ .Values.server.tls.enabled | quote }}
         cert: /etc/platform/certs/tls.crt
         key: /etc/platform/certs/tls.key
       auth:
@@ -31,6 +31,5 @@ data:
         {{- .Values.server.auth | toYaml | nindent 8 }}
       cryptoProvider:
         {{- .Values.server.cryptoProvider | toYaml | nindent 8 }}
-      
     opa:
-      embedded: {{ .Values.opa.embedded }}
+      embedded: {{ .Values.opa.embedded | quote }}

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -194,12 +194,12 @@ server:
     standard:
       rsa:
         key1:
-          privateKeyPath: /etc/platform/kas/kas-private.pem
-          publicKeyPath: /etc/platform/kas/kas-cert.pem
+          private_key_path: /etc/platform/kas/kas-private.pem
+          public_key_path: /etc/platform/kas/kas-cert.pem
       ec:
         key1:
-          privateKeyPath: /etc/platform/kas/kas-ec-private.pem
-          publicKeyPath: /etc/platform/kas/kas-ec-cert.pem
+          private_key_path: /etc/platform/kas/kas-ec-private.pem
+          public_key_path: /etc/platform/kas/kas-ec-cert.pem
 services:
   entityresolution:
     # -- Entity Resolver service enabled


### PR DESCRIPTION
The kas key paths were changed in the core platform. This pr updates the default value to the new format. 