### PR TITLE
feat!: yaml config for kas

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -332,7 +332,8 @@ realms:
 | services.entityresolution.enabled | bool | `false` | Entity Resolver service enabled |
 | services.entityresolution.realm | string | `"opentdf"` | Entity Resolver Realm |
 | services.entityresolution.url | string | `nil` | Identity Provider Entity Resolver |
-| services.kas.enabled | bool | `true` | KAS service enabled |
+| services.kas.config | object | `{"enabled":true}` | KAS service Configuration as yaml |
+| services.kas.config.enabled | bool | `true` | KAS service enabled |
 | services.kas.privateKeysSecret | string | `"kas-private-keys"` | KAS secret containing keys kas-private.pem , kas-cert.pem , kas-ec-private.pem , kas-ec-cert.pem |
 | tolerations | list | `[]` | Tolerations to apply to the pod (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
 | volumeMounts | list | `[]` | Additional volumeMounts on the output Deployment definition. |

--- a/charts/platform/templates/config.yaml
+++ b/charts/platform/templates/config.yaml
@@ -15,7 +15,7 @@ data:
       entityresolution: 
         {{- .Values.services.entityresolution | toYaml | nindent 8 }}
       kas:
-        enabled: {{ .Values.services.kas.enabled | quote }}
+        {{- .Values.services.kas.config | toYaml | nindent 8 }}
       authorization:
         {{- .Values.services.authorization | toYaml | nindent 8 }}
     server:

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -214,6 +214,7 @@ services:
     realm: opentdf
 
   kas:
+    # -- KAS service Configuration as yaml
     config:
       # -- KAS service enabled
       enabled: true

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -214,8 +214,9 @@ services:
     realm: opentdf
 
   kas:
-    # -- KAS service enabled
-    enabled: true
+    config:
+      # -- KAS service enabled
+      enabled: true
     # -- KAS secret containing keys
     # kas-private.pem , kas-cert.pem , kas-ec-private.pem , kas-ec-cert.pem
     privateKeysSecret: kas-private-keys


### PR DESCRIPTION
Kas configuration as yaml.  Added under config vs under KAS to not disturb privateKeysSecret and not include privateKeysSecret in the config

This was to support additional configuration for KAS where no chart value exists; such as  **eccertid**

**This would be a breaking change for downstream charts**