### PR TITLE
feat(platform): add headless service

### DIFF
--- a/charts/platform/templates/headless-service.yaml
+++ b/charts/platform/templates/headless-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-headless" (include "chart.fullname" .) }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http2
+      appProtocol:  {{ if .Values.server.tls.enabled }}http2{{ else }}h2c{{ end }}      
+      protocol: TCP
+      name: http2
+  selector:
+    {{- include "chart.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Adds a headless service so other grpc clients can load balance within k8s