### PR TITLE
fix(platform): extra certs overwriting files in /etc/ssl/certs

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -290,7 +290,7 @@ realms:
 | playground | bool | `false` |  |
 | podAnnotations | object | `{}` | Extra annotations to add to the pod |
 | podLabels | object | `{}` | Extra labels to add to the pod |
-| podSecurityContext | object | `{}` | The pod security context |
+| podSecurityContext | object | `{}` | The pod security context (https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | postgresql.auth.database | string | `"opentdf"` |  |
 | postgresql.auth.enablePostgresUser | bool | `false` |  |
 | postgresql.auth.existingSecret | string | `"opentdf-db-credentials"` |  |
@@ -302,7 +302,7 @@ realms:
 | postgresql.tls.enabled | bool | `true` |  |
 | replicaCount | int | `1` | The number of Platform pods to run |
 | resources | object | `{}` | Resources to allocate to the container |
-| securityContext | object | `{}` | The container security context |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | The container security context (https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
 | server.auth.audience | string | `"http://localhost:8080"` | Audience of provided by the identity provider |
 | server.auth.issuer | string | `"http://platform-keycloak/realms/opentdf"` | Identity provider issuer |
 | server.auth.policy.claim | string | `nil` |  |

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -1,6 +1,6 @@
 # platform
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: nightly](https://img.shields.io/badge/AppVersion-nightly-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: nightly](https://img.shields.io/badge/AppVersion-nightly-informational?style=flat-square)
 
 A Helm Chart for OpenTDF Platform
 
@@ -290,7 +290,7 @@ realms:
 | playground | bool | `false` |  |
 | podAnnotations | object | `{}` | Extra annotations to add to the pod |
 | podLabels | object | `{}` | Extra labels to add to the pod |
-| podSecurityContext | object | `{}` | The pod security context (https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
+| podSecurityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | The pod security context (https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | postgresql.auth.database | string | `"opentdf"` |  |
 | postgresql.auth.enablePostgresUser | bool | `false` |  |
 | postgresql.auth.existingSecret | string | `"opentdf-db-credentials"` |  |

--- a/charts/platform/templates/deployment.yaml
+++ b/charts/platform/templates/deployment.yaml
@@ -109,9 +109,8 @@ spec:
         {{- end }}
         - name: trusted-certs
           projected:
-            defaultMode: 0400
             sources:
-            {{- if and .Values.playground .Values.keycloak.ingress.tls }}
+            {{- if and .Values.playground .Values.keycloak.ingress.enabled .Values.keycloak.ingress.tls }}
             - secret:
                 name: {{ .Values.keycloak.ingress.hostname }}-tls # If the fullnameOverride is set, this will break
                 optional: false

--- a/charts/platform/templates/deployment.yaml
+++ b/charts/platform/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
               mountPath: /etc/platform/kas
             - name: trusted-certs
               readOnly: true
-              mountPath: /etc/ssl/certs
+              mountPath: /etc/ssl/certs/platform
             {{- if .Values.server.tls.enabled }}
             - name: tls
               readOnly: true
@@ -81,6 +81,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
+          - name: SSL_CERT_DIR
+            value: '/etc/ssl/certs:/etc/ssl/certs/platform'
           - name: {{include "platform.envVarPrefix" .}}_DB_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -45,20 +45,22 @@ hostAliases: []
   #   hostnames:
   #     - service.local.lab
 
-# -- The pod security context
+# -- The pod security context (https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
 podSecurityContext:
   {}
   # fsGroup: 2000
 
-# -- The container security context
+# -- The container security context (https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
+  capabilities:
+    drop:
+    - ALL
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
   # runAsUser: 1000
+  seccompProfile:
+    type: "RuntimeDefault"
 
 service:
   # -- The type of service to create

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -47,7 +47,9 @@ hostAliases: []
 
 # -- The pod security context (https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
 podSecurityContext:
-  {}
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
   # fsGroup: 2000
 
 # -- The container security context (https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)


### PR DESCRIPTION
fix: remove defaultMode on trusted-certs volume
fix: only mount keycloak cert if ingress and tls enabled
fix: set default security context values for container
fix: set pod security context defaults