### PR TITLE
fix: correct h2c service appProtocol

### DIFF
--- a/charts/platform/templates/headless-service.yaml
+++ b/charts/platform/templates/headless-service.yaml
@@ -12,7 +12,7 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http2
-      appProtocol:  {{ if .Values.server.tls.enabled }}http2{{ else }}h2c{{ end }}      
+      appProtocol:  {{ if .Values.server.tls.enabled }}http2{{ else }}kubernetes.io/h2c{{ end }}
       protocol: TCP
       name: http2
   selector:

--- a/charts/platform/templates/service.yaml
+++ b/charts/platform/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http2
-      appProtocol:  {{ if .Values.server.tls.enabled }}http2{{ else }}h2c{{ end }}      
+      appProtocol:  {{ if .Values.server.tls.enabled }}http2{{ else }}kubernetes.io/h2c{{ end }}
       protocol: TCP
       name: http2
   selector:


### PR DESCRIPTION
Platform's service `appProtocol` is `h2c`. According to [kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol), it should be `kubernetes.io/h2c`.

HTTP Requests were being received as HTTP/1.1, rather than HTTP2 causing gRPC requests to fail.