### PR TITLE
fix: port naming/app protocol tls.enabled

### DIFF
--- a/charts/platform/templates/_helpers.tpl
+++ b/charts/platform/templates/_helpers.tpl
@@ -132,9 +132,17 @@ This takes an array of three values:
 {{- end -}}
 {{- end -}}
 
+{{- define "platform.portName" -}}
+{{- if .Values.server.tls.enabled -}}
+https
+{{- else -}}
+http2
+{{- end -}}
+{{- end -}}
+
 {{- define "determine.appProtocol" -}}
 {{- if .Values.server.tls.enabled -}}
-http2
+https
 {{- else -}}
 {{- if (include "isOpenshift" .) -}}
 h2c

--- a/charts/platform/templates/deployment.yaml
+++ b/charts/platform/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: http2
+            - name: {{ include "platform.portName" . }}
               containerPort: {{ .Values.server.port }}
               protocol: TCP
           {{ if not .Values.server.disableHealthChecks }}
@@ -55,12 +55,12 @@ spec:
             httpGet:
               scheme: {{ if .Values.server.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}              
               path: /healthz
-              port: http2
+              port: {{ include "platform.portName" . }}
           readinessProbe:
             httpGet:
               scheme: {{ if .Values.server.tls.enabled }}HTTPS{{ else }}HTTP{{ end }}
               path: /healthz?service=all
-              port: http2
+              port: {{ include "platform.portName" . }}
           {{ end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/platform/templates/service.yaml
+++ b/charts/platform/templates/service.yaml
@@ -10,9 +10,9 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http2
+      targetPort: {{ include "platform.portName" . }}
       appProtocol:  {{ include "determine.appProtocol" . }}
       protocol: TCP
-      name: http2
+      name: {{ include "platform.portName" . }}
   selector:
     {{- include "chart.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
- Add template for platform port name and use in deployment & service.
- Update appProtocol template to use https when tls.enabled

Fixes Istio TLS Passthrough scenario where appProtocol override does not appear to work; so uses port naming instead : https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/