### PR TITLE
fix: add override for appprotocol

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -1,6 +1,6 @@
 # platform
 
-![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.32](https://img.shields.io/badge/AppVersion-v0.4.32-informational?style=flat-square)
+![Version: 0.8.3](https://img.shields.io/badge/Version-0.8.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.32](https://img.shields.io/badge/AppVersion-v0.4.32-informational?style=flat-square)
 
 A Helm Chart for OpenTDF Platform
 
@@ -224,6 +224,7 @@ Download the [keycloak_data.yaml](https://raw.githubusercontent.com/opentdf/plat
 | server.tls.enabled | bool | `false` | Enables tls for platform server |
 | server.tls.secret | string | `nil` | The server tls certificate. If not set, a self-signed certificate is generated |
 | service.annotations | object | `{}` | Extra annotations to add to the service |
+| service.appProtocol | string | `""` | explicit appProtocol for the service |
 | service.port | int | `9000` | The port of the service |
 | service.type | string | `"ClusterIP"` | The type of service to create |
 | serviceAccount.annotations | object | `{}` | Extra annotations to add to the service account |

--- a/charts/platform/templates/service.yaml
+++ b/charts/platform/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ include "platform.portName" . }}
-      appProtocol:  {{ include "determine.appProtocol" . }}
+      appProtocol:  {{ .Values.service.appProtocol | default (include "determine.appProtocol" .) }}
       protocol: TCP
       name: {{ include "platform.portName" . }}
   selector:

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -72,6 +72,8 @@ service:
   port: 9000
   # -- Extra annotations to add to the service
   annotations: {}
+  # -- explicit appProtocol for the service
+  appProtocol: ""
 
 ingress:
   # -- Enable Ingress


### PR DESCRIPTION
- add service.appProtocol value for override default to determine.appProtocol helper function if not defined 

adds the ability to explicitly set the app protocol when tls is true for it work with GCP load balancing