### PR TITLE
feat: Add init containers support to platform deployment

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -1,6 +1,6 @@
 # platform
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.0](https://img.shields.io/badge/AppVersion-v0.7.0-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.0](https://img.shields.io/badge/AppVersion-v0.7.0-informational?style=flat-square)
 
 A Helm Chart for OpenTDF Platform
 
@@ -144,6 +144,7 @@ Download the [keycloak_data.yaml](https://raw.githubusercontent.com/opentdf/plat
 | db.schema | string | `"opentdf"` | The schema for the database. |
 | db.sslmode | string | `"prefer"` | The database ssl mode ( disable, prefer, require, verify-ca, verify-full ) |
 | db.user | string | `"opentdf"` | The database user |
+| deploymentAnnotations | object | `{}` | Extra annotations to add to the deployment |
 | envFrom | list | `[]` | Environment variables from a configmap or secret |
 | extraEnv | list | `[]` | Extra environment variables to add to the container |
 | fullnameOverride | string | `""` | Overrides the generated fullname |
@@ -157,6 +158,7 @@ Download the [keycloak_data.yaml](https://raw.githubusercontent.com/opentdf/plat
 | ingress.enabled | bool | `false` | Enable Ingress |
 | ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}]` | List of hosts for the ingress |
 | ingress.tls | list | `[]` | List of tls hosts |
+| initContainers | list | `[]` | Init containers to run before the main container |
 | keycloak.auth.adminUser | string | `"admin"` |  |
 | keycloak.externalDatabase.database | string | `"opentdf"` |  |
 | keycloak.externalDatabase.existingSecret | string | `"opentdf-db-credentials"` |  |

--- a/charts/platform/templates/deployment.yaml
+++ b/charts/platform/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
       hostAliases:
         {{- toYaml .Values.hostAliases | nindent 8 }}
       {{- end -}}
+      {{- if .Values.initContainers }}
+      initContainers:
+        {{- toYaml .Values.initContainers | nindent 8 }}
+      {{- end }}
       {{  include "platform.util.merge.list" (list $data "volumes" .Values.volumeTemplate "platform.volumes.tpl" ) | nindent 6 }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -150,6 +150,28 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
+# -- Init containers to run before the main container
+initContainers: []
+# Example init container configurations:
+# - name: database-migration
+#   image: registry.opentdf.io/platform:latest
+#   command: ["/bin/sh"]
+#   args: ["-c", "platform migrate up"]
+#   env:
+#   - name: OPENTDF_DB_PASSWORD
+#     valueFrom:
+#       secretKeyRef:
+#         name: opentdf-db-credentials
+#         key: password
+#   volumeMounts:
+#   - name: config
+#     mountPath: /etc/platform/config
+#     readOnly: true
+# - name: setup-data
+#   image: busybox:latest
+#   command: ["/bin/sh"]
+#   args: ["-c", "echo 'Setting up initial data...' && sleep 5"]
+
 # -- Target specific nodes in the cluster
 nodeSelector: {}
 


### PR DESCRIPTION
- Add initContainers configuration to values.yaml
- Update deployment template to conditionally render init containers
- Add unit tests to validate init container functionality

This allows users to specify init containers in their values.yaml: initContainers:
  - name: database-migration image: registry.opentdf.io/platform:latest command: ["/bin/sh"] args: ["-c", "platform migrate up"]