### PR TITLE
chore: DSPX-1240 Downgrading chart version due to failed release creation

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-    "charts/platform": "0.14.0"
+  "charts/platform": "0.12.0"
 }


### PR DESCRIPTION
This release had failed, and there is no 0.13 release. Resetting this manifest