### PR TITLE
fix(platform): DSPX-2933 align KAS root key env var with Viper config path

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -214,7 +214,7 @@ Download the [keycloak_data.yaml](https://raw.githubusercontent.com/opentdf/plat
 | services.kas.config.registered_kas_uri | string | `nil` | Used by key management, if present. |
 | services.kas.privateKeysSecret | string | `"kas-private-keys"` | KAS secret containing keys @deprecated Use `private_keys_secret` instead. This value will be removed in a future release. |
 | services.kas.private_keys_secret | string | `""` | KAS secret containing keys kas-private.pem , kas-cert.pem , kas-ec-private.pem , kas-ec-cert.pem |
-| services.kas.root_key_secret | object | `{"key":"root_key","name":"kas-root-key"}` | Key needed when key_management feature is enabled (openssl rand 32 -hex) openssl rand 32 -hex | kubectl create secret generic kas-root-key --from-file=root_key=/dev/stdin |
+| services.kas.root_key_secret | object | `{"key":"root_key","name":"kas-root-key"}` | Key needed when key_management feature is enabled. Injected as `{PREFIX}_SERVICES_KAS_ROOT_KEY` env var (openssl rand 32 -hex) openssl rand 32 -hex | kubectl create secret generic kas-root-key --from-file=root_key=/dev/stdin |
 | tolerations | list | `[]` | Tolerations to apply to the pod (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
 | trace.enabled | bool | `false` | Enable distributed tracing |
 | trace.provider.file.compress | string | `nil` | Enable compression of trace files |

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -214,7 +214,7 @@ Download the [keycloak_data.yaml](https://raw.githubusercontent.com/opentdf/plat
 | services.kas.config.registered_kas_uri | string | `nil` | Used by key management, if present. |
 | services.kas.privateKeysSecret | string | `"kas-private-keys"` | KAS secret containing keys @deprecated Use `private_keys_secret` instead. This value will be removed in a future release. |
 | services.kas.private_keys_secret | string | `""` | KAS secret containing keys kas-private.pem , kas-cert.pem , kas-ec-private.pem , kas-ec-cert.pem |
-| services.kas.root_key_secret | object | `{"key":"root_key","name":"kas-root-key"}` | Key needed when key_management feature is enabled. Injected as `{PREFIX}_SERVICES_KAS_ROOT_KEY` env var (openssl rand 32 -hex) openssl rand 32 -hex | kubectl create secret generic kas-root-key --from-file=root_key=/dev/stdin |
+| services.kas.root_key_secret | object | `{"key":"root_key","name":"kas-root-key"}` | Key needed when key_management feature is enabled. Injected as `{PREFIX}_SERVICES_KAS_ROOT_KEY` env var (openssl rand 32 -hex) openssl rand 32 -hex \| kubectl create secret generic kas-root-key --from-file=root_key=/dev/stdin |
 | tolerations | list | `[]` | Tolerations to apply to the pod (https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) |
 | trace.enabled | bool | `false` | Enable distributed tracing |
 | trace.provider.file.compress | string | `nil` | Enable compression of trace files |

--- a/charts/platform/templates/deployment.yaml
+++ b/charts/platform/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
                 key: {{ .Values.sdk_config.existingSecret.key }}
           {{- end }}
           {{- if and (or (contains "all" .Values.mode) (contains "kas" .Values.mode)) .Values.services.kas.config.preview.key_management }}
-          - name: {{include "platform.envVarPrefix" .}}_KAS_ROOT_KEY
+          - name: {{include "platform.envVarPrefix" .}}_SERVICES_KAS_ROOT_KEY
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.services.kas.root_key_secret.name }}

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -478,7 +478,7 @@ services:
           alg: ec:secp256r1
         - kid: r1
           alg: rsa:2048
-    # -- Key needed when key_management feature is enabled (openssl rand 32 -hex)
+    # -- Key needed when key_management feature is enabled. Injected as `{PREFIX}_SERVICES_KAS_ROOT_KEY` env var (openssl rand 32 -hex)
     # openssl rand 32 -hex | kubectl create secret generic kas-root-key --from-file=root_key=/dev/stdin
     root_key_secret:
       name: kas-root-key

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -479,7 +479,7 @@ services:
         - kid: r1
           alg: rsa:2048
     # -- Key needed when key_management feature is enabled. Injected as `{PREFIX}_SERVICES_KAS_ROOT_KEY` env var (openssl rand 32 -hex)
-    # openssl rand 32 -hex | kubectl create secret generic kas-root-key --from-file=root_key=/dev/stdin
+    # openssl rand 32 -hex \| kubectl create secret generic kas-root-key --from-file=root_key=/dev/stdin
     root_key_secret:
       name: kas-root-key
       key: root_key

--- a/tests/chart_platform_template_test.go
+++ b/tests/chart_platform_template_test.go
@@ -944,7 +944,7 @@ func (s *PlatformChartTemplateSuite) Test_KeyManagement_Enabled_With_RootKeySecr
 	envVarFound := false
 	for _, container := range deployment.Spec.Template.Spec.Containers {
 		for _, envVar := range container.Env {
-			if envVar.Name == "OPENTDF_KAS_ROOT_KEY" {
+			if envVar.Name == "OPENTDF_SERVICES_KAS_ROOT_KEY" {
 				s.Require().Equal("my-root-key-secret", envVar.ValueFrom.SecretKeyRef.Name)
 				s.Require().Equal("my-root-key", envVar.ValueFrom.SecretKeyRef.Key)
 				envVarFound = true


### PR DESCRIPTION
## Summary

The Helm deployment template currently injects the KAS root key secret as the environment variable `{PREFIX}_KAS_ROOT_KEY` (e.g. `DSP_KAS_ROOT_KEY`). However, Viper maps the YAML config path `services.kas.root_key` to the env var `{PREFIX}_SERVICES_KAS_ROOT_KEY` — the `SERVICES_KAS_` segment was missing.

This PR updates:
- **`charts/platform/templates/deployment.yaml`** — changes `_KAS_ROOT_KEY` → `_SERVICES_KAS_ROOT_KEY`
- **`tests/chart_platform_template_test.go`** — updates the unit test assertion from `OPENTDF_KAS_ROOT_KEY` → `OPENTDF_SERVICES_KAS_ROOT_KEY`

This aligns the chart with the documentation updated in [virtru-corp/data-security-platform#2826](https://github.com/virtru-corp/data-security-platform/pull/2826), which documents `DSP_SERVICES_KAS_ROOT_KEY` as the correct env var.

### ⚠️ Breaking Change Note
Deployments that rely on the chart's auto-injected `root_key_secret` env var will see the variable name change from `{PREFIX}_KAS_ROOT_KEY` to `{PREFIX}_SERVICES_KAS_ROOT_KEY`. Existing `extraEnv` overrides that already set `DSP_SERVICES_KAS_ROOT_KEY` are unaffected. Deployments using the old chart-injected variable should verify their KAS pods pick up the root key correctly after upgrading.

## Test plan
- [ ] Verify `Test_KeyManagement_Enabled_With_RootKeySecret_Expect_EnvVar_Set` passes with the updated assertion
- [ ] Deploy to a dev cluster and confirm KAS starts successfully with key management enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed the Kas root key environment variable to the services-prefixed form (OPENTDF_SERVICES_KAS_ROOT_KEY) for consistency.
* **Documentation**
  * Updated chart README and values comments to document the injected services-prefixed root key and clarify it’s generated as a random 32-byte hex value (openssl rand 32 -hex).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->