### PR TITLE
ci(platform): add helm-docs freshness check to lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -49,3 +49,26 @@ jobs:
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
         run: ls -la && ct lint --check-version-increment=false --target-branch ${{ github.event.repository.default_branch }} --lint-conf ./.lintconf.yaml
+
+      - name: Install helm-docs
+        if: steps.list-changed.outputs.changed == 'true'
+        env:
+          HELM_DOCS_VERSION: '1.14.2'
+        run: |
+          curl -sSLO "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz"
+          tar -xzf "helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" -C /tmp helm-docs
+          rm "helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz"
+
+      - name: Run helm-docs
+        if: steps.list-changed.outputs.changed == 'true'
+        run: /tmp/helm-docs
+
+      - name: Fail if docs are not up-to-date
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          if ! git diff --quiet; then
+            echo "::error::Helm docs are not up-to-date. Run 'helm-docs' locally and commit the changes."
+            git diff --stat
+            git diff
+            exit 1
+          fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -53,22 +53,26 @@ jobs:
       - name: Install helm-docs
         if: steps.list-changed.outputs.changed == 'true'
         env:
-          HELM_DOCS_VERSION: '1.14.2'
+          # Keep in sync with .pre-commit-config.yaml
+          HELM_DOCS_VERSION: '1.13.1'
+          HELM_DOCS_SHA256: 'df8d803506933ceb92bc2996d8a432059a35fc19a308ac37a141971ffdf7aa33'
         run: |
           curl -sSLO "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz"
+          echo "${HELM_DOCS_SHA256}  helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" | sha256sum -c --quiet --strict
           tar -xzf "helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" -C /tmp helm-docs
           rm "helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz"
 
       - name: Run helm-docs
         if: steps.list-changed.outputs.changed == 'true'
-        run: /tmp/helm-docs
+        # --chart-search-root=charts matches .pre-commit-config.yaml so local and CI behaviour are identical
+        run: /tmp/helm-docs --chart-search-root=charts
 
       - name: Fail if docs are not up-to-date
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          if ! git diff --quiet; then
+          if ! git diff --quiet -- 'charts/*/README.md'; then
             echo "::error::Helm docs are not up-to-date. Run 'helm-docs' locally and commit the changes."
-            git diff --stat
-            git diff
+            git diff --stat -- 'charts/*/README.md'
+            git diff -- 'charts/*/README.md'
             exit 1
           fi


### PR DESCRIPTION
## Summary

Adds a `helm-docs` freshness gate to the existing `Helm Lint` workflow. After `ct lint` passes, the job runs `helm-docs` and fails if any `README.md` is stale with respect to `values.yaml`.

## Why

Without this check, `values.yaml` changes that affect the docs table can merge without the `README.md` being updated, causing the generated documentation to drift silently.

## Implementation

- Installs `helm-docs` v1.14.2 from the official GitHub release tarball
- Runs after `ct lint` on the same `list-changed` gate so it only executes when chart files are modified
- Fails with a clear error message and shows the diff if docs are out of date

## Test plan

- [x] Workflow syntax validated locally
- [ ] Merging a `values.yaml` change without running `helm-docs` should fail the lint job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Helm chart documentation validation to the lint workflow to ensure chart documentation remains accurate and synchronized with repository changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->