### PR TITLE
fix(platform): DSPX-4207 align server.cors defaults with OpenTDF platform config

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -1,6 +1,6 @@
 # platform
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
 
 A Helm Chart for OpenTDF Platform
 
@@ -169,8 +169,8 @@ Download the [keycloak_data.yaml](https://raw.githubusercontent.com/opentdf/plat
 | server.cors.additionalheaders | list | `[]` | Additional allowed headers to append to the default list (additive) |
 | server.cors.additionalmethods | list | `[]` | Additional HTTP methods to append to the default list (additive) |
 | server.cors.allowcredentials | bool | `true` | Allow credentials |
-| server.cors.allowedheaders | list | `["Accept","Authorization","Content-Type","X-CSRF-Token","X-Request-ID"]` | The allowed request headers |
-| server.cors.allowedmethods | list | `["GET","POST","PUT","DELETE","OPTIONS"]` | The allowed request methods |
+| server.cors.allowedheaders | list | `["Accept","Accept-Encoding","Authorization","Connect-Protocol-Version","Content-Length","Content-Type","Dpop","X-CSRF-Token","X-Requested-With","X-Rewrap-Additional-Context"]` | The allowed request headers |
+| server.cors.allowedmethods | list | `["GET","POST","PATCH","PUT","DELETE","OPTIONS"]` | The allowed request methods |
 | server.cors.allowedorigins | list | `[]` | The allowed origins |
 | server.cors.enabled | bool | `false` | Enable CORS (default: false) |
 | server.cors.exposedheaders | list | `["Link"]` | List of response headers that browsers are allowed to access |

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -268,16 +268,22 @@ server:
     allowedmethods:
       - "GET"
       - "POST"
+      - "PATCH"
       - "PUT"
       - "DELETE"
       - "OPTIONS"
     # -- The allowed request headers
     allowedheaders:
       - "Accept"
+      - "Accept-Encoding"
       - "Authorization"
+      - "Connect-Protocol-Version"
+      - "Content-Length"
       - "Content-Type"
+      - "Dpop"
       - "X-CSRF-Token"
-      - "X-Request-ID"
+      - "X-Requested-With"
+      - "X-Rewrap-Additional-Context"
     # -- List of response headers that browsers are allowed to access
     exposedheaders:
       - Link


### PR DESCRIPTION
## What

Update the platform chart's default `server.cors` values to match the OpenTDF platform's built-in CORS defaults:

- **`allowedmethods`**: add `PATCH` → `GET, POST, PATCH, PUT, DELETE, OPTIONS`
- **`allowedheaders`**: expand to `Accept, Accept-Encoding, Authorization, Connect-Protocol-Version, Content-Length, Content-Type, Dpop, X-CSRF-Token, X-Requested-With, X-Rewrap-Additional-Context`

`README.md` regenerated via helm-docs (also picks up the stale `0.15.0` version badge).

## Why

The chart's default `allowedheaders`/`allowedmethods` had drifted from the platform binary's own defaults. In particular the chart was missing `X-Rewrap-Additional-Context` (and other browser headers), which the platform ships by default.

Source of truth for the new defaults:
- `service/internal/server/server.go` (`AllowedHeaders`/`AllowedMethods` struct defaults)
- `opentdf-example.yaml` `server.cors`

This lets browser clients such as the Virtru DSP **Secure Viewer** get working CORS from the chart defaults, so downstream charts no longer need to re-declare the entire `server.cors` block.

## Notes

- No `Chart.yaml`/`CHANGELOG.md` bump — release-please owns versioning.
- `server.cors.enabled` default is unchanged (`false`); enabling CORS and setting `allowedorigins` remains a per-deployment concern.

## Related

- Replaces the downstream workaround in virtru-corp/charts#237 (per review feedback to make this an opentdf chart change).
- Docs/sample-values context: virtru-corp/dsp-bundle#288, virtru-corp/data-security-platform#3528.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Expanded cross-origin request support with additional permitted headers.
  - Added support for `PATCH` requests.
  - Updated the platform chart version badge to `0.15.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->