### PR TITLE
ci(platform): auto-regenerate helm-docs README on release-please PRs

### DIFF
--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -1,0 +1,70 @@
+name: Release Docs Sync
+
+# release-please bumps chart versions in Chart.yaml but does not run helm-docs,
+# so the version badge in each chart README goes stale on the release PR and the
+# "Helm Lint -> Fail if docs are not up-to-date" gate fails on every release.
+#
+# This workflow watches release-please PRs, regenerates the helm-docs README, and
+# commits the result back to the release branch so the lint gate stays green
+# without anyone hand-editing the auto-generated release PR.
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+# The default token is only used for read; pushes use the app token below.
+permissions:
+  contents: read
+
+jobs:
+  helm-docs:
+    # Only touch release-please's own PR branches.
+    if: startsWith(github.event.pull_request.head.ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@f2acddfb5195534d487896a656232b016a682f3c # v1.9.0
+        with:
+          app-id: "${{ secrets.APP_ID }}"
+          private-key: "${{ secrets.AUTOMATION_KEY }}"
+
+      - name: Checkout release branch
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          token: "${{ steps.generate_token.outputs.token }}"
+          ref: "${{ github.event.pull_request.head.ref }}"
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Install helm-docs
+        env:
+          # Keep in sync with .github/workflows/lint.yaml and .pre-commit-config.yaml
+          HELM_DOCS_VERSION: '1.13.1'
+          HELM_DOCS_SHA256: 'df8d803506933ceb92bc2996d8a432059a35fc19a308ac37a141971ffdf7aa33'
+        run: |
+          curl -sSLO "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz"
+          echo "${HELM_DOCS_SHA256}  helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" | sha256sum -c --quiet --strict
+          tar -xzf "helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz" -C /tmp helm-docs
+          rm "helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz"
+
+      - name: Run helm-docs
+        # --chart-search-root=charts matches lint.yaml so local, lint, and release output are identical
+        run: /tmp/helm-docs --chart-search-root=charts
+
+      - name: Commit regenerated README(s)
+        run: |
+          if git diff --quiet -- 'charts/*/README.md'; then
+            echo "helm-docs README already up to date; nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add charts/*/README.md
+          git commit -s -m "docs: regenerate helm-docs README for release"
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"

--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -33,6 +33,8 @@ jobs:
         with:
           app-id: "${{ secrets.APP_ID }}"
           private-key: "${{ secrets.AUTOMATION_KEY }}"
+          # Scope the token to only what this workflow needs: push regenerated READMEs.
+          permission-contents: write
 
       - name: Checkout release branch
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -58,6 +60,10 @@ jobs:
         run: /tmp/helm-docs --chart-search-root=charts
 
       - name: Commit regenerated README(s)
+        # Pass the untrusted branch name through env, never inline in the shell script,
+        # to avoid template-expansion code injection from a crafted branch name.
+        env:
+          HEAD_REF: "${{ github.event.pull_request.head.ref }}"
         run: |
           if git diff --quiet -- 'charts/*/README.md'; then
             echo "helm-docs README already up to date; nothing to commit."
@@ -67,4 +73,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add charts/*/README.md
           git commit -s -m "docs: regenerate helm-docs README for release"
-          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+          git push origin "HEAD:${HEAD_REF}"

--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -72,6 +72,7 @@ jobs:
         run: |
           mapfile -d '' changed_readmes < <(
             git diff --name-only --diff-filter=AM -z -- 'charts/*/README.md'
+            git ls-files --others --exclude-standard -z -- 'charts/*/README.md'
           )
           if (( ${#changed_readmes[@]} == 0 )); then
             echo "helm-docs README already up to date; nothing to commit."

--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -61,16 +61,76 @@ jobs:
 
       - name: Commit regenerated README(s)
         # Pass the untrusted branch name through env, never inline in the shell script,
-        # to avoid template-expansion code injection from a crafted branch name.
+        # to avoid template-expansion code injection from a crafted branch name. The
+        # GraphQL mutation creates one atomic commit that GitHub signs and verifies.
         env:
+          DCO_SIGNOFF: >-
+            Signed-off-by: opentdf-automation[bot]
+            <149537512+opentdf-automation[bot]@users.noreply.github.com>
+          GH_TOKEN: "${{ steps.generate_token.outputs.token }}"
           HEAD_REF: "${{ github.event.pull_request.head.ref }}"
         run: |
-          if git diff --quiet -- 'charts/*/README.md'; then
+          mapfile -d '' changed_readmes < <(
+            git diff --name-only --diff-filter=AM -z -- 'charts/*/README.md'
+          )
+          if (( ${#changed_readmes[@]} == 0 )); then
             echo "helm-docs README already up to date; nothing to commit."
             exit 0
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add charts/*/README.md
-          git commit -s -m "docs: regenerate helm-docs README for release"
-          git push origin "HEAD:${HEAD_REF}"
+
+          additions='[]'
+          for file in "${changed_readmes[@]}"; do
+            contents=$(base64 -w 0 -- "$file")
+            additions=$(jq -c \
+              --arg path "$file" \
+              --arg contents "$contents" \
+              '. + [{path: $path, contents: $contents}]' \
+              <<< "$additions")
+          done
+
+          query='mutation CreateCommit($input: CreateCommitOnBranchInput!) {
+            createCommitOnBranch(input: $input) {
+              commit {
+                oid
+                url
+                signature {
+                  isValid
+                  wasSignedByGitHub
+                }
+              }
+            }
+          }'
+
+          response=$(jq -n \
+            --arg query "$query" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg branch "$HEAD_REF" \
+            --arg head "$(git rev-parse HEAD)" \
+            --arg body "$DCO_SIGNOFF" \
+            --argjson additions "$additions" \
+            '{
+              query: $query,
+              variables: {
+                input: {
+                  branch: {
+                    repositoryNameWithOwner: $repository,
+                    branchName: $branch
+                  },
+                  expectedHeadOid: $head,
+                  message: {
+                    headline: "docs: regenerate helm-docs README for release",
+                    body: $body
+                  },
+                  fileChanges: {additions: $additions}
+                }
+              }
+            }' | gh api graphql --input -)
+
+          jq -e '
+            .data.createCommitOnBranch.commit.signature
+            | .isValid and .wasSignedByGitHub
+          ' <<< "$response" > /dev/null
+          jq -r '
+            "Created verified commit \(.data.createCommitOnBranch.commit.oid): "
+            + .data.createCommitOnBranch.commit.url
+          ' <<< "$response"


### PR DESCRIPTION
## Summary

Durable fix for the recurring Helm Lint failure on release-please PRs (follow-up to the manual README regen on #200).

**Root cause:** release-please bumps the chart `version` in `Chart.yaml` but does not run `helm-docs`. The README version badge is rendered by helm-docs from `Chart.yaml`, so on every release PR the badge goes stale (e.g. `0.15.0` while `Chart.yaml` says `0.16.0`). The Helm Lint job runs helm-docs and then fails on the **"Fail if docs are not up-to-date"** step because the committed README differs from the regenerated one. This is exactly why PR #200 (platform `0.16.0`) failed lint.

**Fix:** Add a `Release Docs Sync` workflow that:
- triggers on PRs to `main` whose head branch starts with `release-please--`,
- runs `helm-docs` (same pinned `1.13.1` version + SHA and `--chart-search-root=charts` as `lint.yaml`, so output is byte-identical to what the lint gate expects),
- collects both modified and newly generated untracked `charts/*/README.md` files,
- creates one atomic, GitHub-signed commit on the release branch through the `createCommitOnBranch` GraphQL mutation, only when documentation changed, and verifies the returned GitHub signature.

The mutation uses the existing GitHub App token (`APP_ID` / `AUTOMATION_KEY`, the same app release-please uses), so the follow-up commit re-triggers the required checks and the lint gate goes green on its own. The commit and DCO sign-off use the app's `opentdf-automation[bot]` identity. If the README is already current, the job is a no-op, so it self-heals when release-please force-updates its branch on the next release.

## Why a workflow and not release-please `extra-files`
The README badge is owned/generated by helm-docs. A release-please `extra-files` annotation comment placed in `README.md` would be stripped the next time helm-docs runs (in the lint gate), reintroducing a diff. Regenerating with helm-docs on the release branch keeps a single source of truth and matches how the repo already produces docs (lint + pre-commit).

## Notes
- Scoped to release-please branches via the job-level `if`, so it never runs on normal contributor PRs.
- The generated commit and DCO sign-off use the `opentdf-automation[bot]` identity from the GitHub App token to satisfy the DCO check.
- The workflow fails if GitHub does not report the generated commit as valid and GitHub-signed.

## Test plan
- [ ] On the next platform release PR, confirm `Release Docs Sync` creates one verified README regeneration commit and the `lint` check goes green without manual edits.
- [ ] Confirm the generated commit passes the DCO check as `opentdf-automation[bot]`.
- [ ] Confirm the workflow is a no-op (no commit) when the README is already up to date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added automated documentation updates for release pull requests.
  * Chart documentation is regenerated and committed when changes are detected.
  * Documentation remains unchanged when it is already current.
  * Updates are applied consistently to the release branch, helping keep chart documentation synchronized before release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
