### PR TITLE
feat(core): Make key_management stable.

### DIFF
--- a/charts/platform/Chart.yaml
+++ b/charts/platform/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.16.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.8.1"
+appVersion: "v0.25.1"
 
 maintainers:
   - name: Opentdf

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -207,7 +207,7 @@ Download the [keycloak_data.yaml](https://raw.githubusercontent.com/opentdf/plat
 | services.entityresolution.url | string | `nil` | Identity Provider Entity Resolver |
 | services.extraServices | object | `{}` | Additional services |
 | services.kas.config | object | `{"key_management":false,"keyring":[{"alg":"ec:secp256r1","kid":"e1"},{"alg":"rsa:2048","kid":"r1"}],"preview":{"ec_tdf_enabled":false},"registered_kas_uri":null,"root_key":null}` | KAS service Configuration as yaml |
-| services.kas.config.key_management | bool | `false` | Whether stable, policy-backed key management is enabled. |
+| services.kas.config.key_management | bool | `false` | Whether key management is enabled. |
 | services.kas.config.keyring | list | `[{"alg":"ec:secp256r1","kid":"e1"},{"alg":"rsa:2048","kid":"r1"}]` | Default keys for clients to use |
 | services.kas.config.preview | object | `{"ec_tdf_enabled":false}` | Preview feature enablement. The deprecated preview.key_management value remains accepted for backwards compatibility. |
 | services.kas.config.preview.ec_tdf_enabled | bool | `false` | Whether tdf based ecc support is enabled. |

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -206,11 +206,11 @@ Download the [keycloak_data.yaml](https://raw.githubusercontent.com/opentdf/plat
 | services.entityresolution.subgroups | bool | `false` | Subgroups |
 | services.entityresolution.url | string | `nil` | Identity Provider Entity Resolver |
 | services.extraServices | object | `{}` | Additional services |
-| services.kas.config | object | `{"keyring":[{"alg":"ec:secp256r1","kid":"e1"},{"alg":"rsa:2048","kid":"r1"}],"preview":{"ec_tdf_enabled":false,"key_management":false},"registered_kas_uri":null,"root_key":null}` | KAS service Configuration as yaml |
+| services.kas.config | object | `{"key_management":false,"keyring":[{"alg":"ec:secp256r1","kid":"e1"},{"alg":"rsa:2048","kid":"r1"}],"preview":{"ec_tdf_enabled":false},"registered_kas_uri":null,"root_key":null}` | KAS service Configuration as yaml |
+| services.kas.config.key_management | bool | `false` | Whether stable, policy-backed key management is enabled. |
 | services.kas.config.keyring | list | `[{"alg":"ec:secp256r1","kid":"e1"},{"alg":"rsa:2048","kid":"r1"}]` | Default keys for clients to use |
-| services.kas.config.preview | object | `{"ec_tdf_enabled":false,"key_management":false}` | Preview feature enablement |
+| services.kas.config.preview | object | `{"ec_tdf_enabled":false}` | Preview feature enablement. The deprecated preview.key_management value remains accepted for backwards compatibility. |
 | services.kas.config.preview.ec_tdf_enabled | bool | `false` | Whether tdf based ecc support is enabled. |
-| services.kas.config.preview.key_management | bool | `false` | Whether new key management features are enabled. |
 | services.kas.config.registered_kas_uri | string | `nil` | Used by key management, if present. |
 | services.kas.privateKeysSecret | string | `"kas-private-keys"` | KAS secret containing keys @deprecated Use `private_keys_secret` instead. This value will be removed in a future release. |
 | services.kas.private_keys_secret | string | `""` | KAS secret containing keys kas-private.pem , kas-cert.pem , kas-ec-private.pem , kas-ec-cert.pem |

--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -1,6 +1,6 @@
 # platform
 
-![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.8.1](https://img.shields.io/badge/AppVersion-v0.8.1-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.25.1](https://img.shields.io/badge/AppVersion-v0.25.1-informational?style=flat-square)
 
 A Helm Chart for OpenTDF Platform
 

--- a/charts/platform/templates/_helpers.tpl
+++ b/charts/platform/templates/_helpers.tpl
@@ -90,9 +90,13 @@ Create the name of the service account to use
 {{- end }}
 {{- end -}}
 
+{{- define "platform.kas.keyManagementEnabled" -}}
+{{- or (dig "key_management" false .Values.services.kas.config) (dig "preview" "key_management" false .Values.services.kas.config) -}}
+{{- end -}}
+
 {{- define "platform.kas.validate" -}}
-{{- if and .Values.services.kas.config.preview.key_management (not (and .Values.services.kas.root_key_secret.name .Values.services.kas.root_key_secret.key)) }}
-{{- fail "When services.kas.config.preview.key_management is true, you must set both services.kas.root_key_secret.name and services.kas.root_key_secret.key" }}
+{{- if and (eq (include "platform.kas.keyManagementEnabled" .) "true") (not (and .Values.services.kas.root_key_secret.name .Values.services.kas.root_key_secret.key)) }}
+{{- fail "When key management is enabled through services.kas.config.key_management or services.kas.config.preview.key_management, you must set both services.kas.root_key_secret.name and services.kas.root_key_secret.key" }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/platform/templates/deployment.yaml
+++ b/charts/platform/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
                 name: {{ .Values.sdk_config.existingSecret.name }}
                 key: {{ .Values.sdk_config.existingSecret.key }}
           {{- end }}
-          {{- if and (or (contains "all" .Values.mode) (contains "kas" .Values.mode)) .Values.services.kas.config.preview.key_management }}
+          {{- if and (or (contains "all" .Values.mode) (contains "kas" .Values.mode)) (eq (include "platform.kas.keyManagementEnabled" .) "true") }}
           - name: {{include "platform.envVarPrefix" .}}_SERVICES_KAS_ROOT_KEY
             valueFrom:
               secretKeyRef:

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -470,12 +470,12 @@ services:
       # -- The URI this KAS is registered with in the platform database.
       # -- Used by key management, if present.
       registered_kas_uri:
-      # -- Preview feature enablement
+      # -- Whether key management is enabled.
+      key_management: false
+      # -- Preview feature enablement. The deprecated preview.key_management value remains accepted for backwards compatibility.
       preview:
         # -- Whether tdf based ecc support is enabled.
         ec_tdf_enabled: false
-        # -- Whether new key management features are enabled.
-        key_management: false
 
       root_key:
       # -- Default keys for clients to use

--- a/tests/bats/e2e.bats
+++ b/tests/bats/e2e.bats
@@ -520,8 +520,14 @@ setup() {
 
 
 @test "Create and Decrypt with External KAS" {
-  # Check we can reach kas.opentdf.local
-  run curl -f -sS https://kas.opentdf.local:9443/kas/v2/kas_public_key
+  # Check we can reach the unauthenticated Connect RPC public-key endpoint.
+  # The legacy /kas/v2/kas_public_key HTTP route requires authentication in
+  # current Platform releases.
+  run curl -f -sS \
+    -H "Content-Type: application/json" \
+    -H "Connect-Protocol-Version: 1" \
+    --data '{}' \
+    https://kas.opentdf.local:9443/kas.AccessService/PublicKey
   if [ "$status" -ne 0 ]; then
     echo "Error: 'curl kas public key' failed with status $status." >&2
     echo "Output: $output" >&2

--- a/tests/chart_platform_template_test.go
+++ b/tests/chart_platform_template_test.go
@@ -904,54 +904,92 @@ func (s *PlatformChartTemplateSuite) Test_Two_SDK_Config_Connections_Are_Set_Whe
 	s.Require().IsType("", endpoint2, "sdk_config.core2.endpoint should be a string")
 }
 
-func (s *PlatformChartTemplateSuite) Test_KeyManagement_Enabled_Without_RootKeySecret_Expect_Error() {
-	releaseName := "key-management-no-secret"
-
-	namespaceName := "opentdf-" + strings.ToLower(random.UniqueId())
-
-	options := &helm.Options{
-		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
-		SetValues: map[string]string{
-			"services.kas.config.preview.key_management": "true",
-			"services.kas.root_key_secret.name":          "",
-			"services.kas.root_key_secret.key":           "",
-		},
+func (s *PlatformChartTemplateSuite) Test_KeyManagement_FlagCompatibility() {
+	tests := []struct {
+		name                string
+		stableValue         string
+		previewValue        string
+		keyManagementActive bool
+	}{
+		{name: "flags omitted", keyManagementActive: false},
+		{name: "both disabled", stableValue: "false", previewValue: "false", keyManagementActive: false},
+		{name: "preview enabled", stableValue: "false", previewValue: "true", keyManagementActive: true},
+		{name: "stable enabled", stableValue: "true", previewValue: "false", keyManagementActive: true},
+		{name: "both enabled", stableValue: "true", previewValue: "true", keyManagementActive: true},
 	}
 
-	_, err := helm.RenderTemplateE(s.T(), options, s.chartPath, releaseName, []string{})
-	s.Require().Error(err)
-	s.Require().ErrorContains(err, "When services.kas.config.preview.key_management is true, you must set both services.kas.root_key_secret.name and services.kas.root_key_secret.key")
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			releaseName := "key-management-" + strings.ReplaceAll(test.name, " ", "-")
+			namespaceName := "opentdf-" + strings.ToLower(random.UniqueId())
+			setValues := map[string]string{
+				"services.kas.root_key_secret.name": "my-root-key-secret",
+				"services.kas.root_key_secret.key":  "my-root-key",
+			}
+			if test.stableValue != "" {
+				setValues["services.kas.config.key_management"] = test.stableValue
+			}
+			if test.previewValue != "" {
+				setValues["services.kas.config.preview.key_management"] = test.previewValue
+			}
+
+			options := &helm.Options{
+				KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+				SetValues:      setValues,
+			}
+			output := helm.RenderTemplate(s.T(), options, s.chartPath, releaseName, []string{"templates/deployment.yaml"})
+			var deployment appv1.Deployment
+			helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+			var rootKeyEnvVars []corev1.EnvVar
+			for _, container := range deployment.Spec.Template.Spec.Containers {
+				for _, envVar := range container.Env {
+					if envVar.Name == "OPENTDF_SERVICES_KAS_ROOT_KEY" {
+						rootKeyEnvVars = append(rootKeyEnvVars, envVar)
+					}
+				}
+			}
+
+			if test.keyManagementActive {
+				s.Require().Len(rootKeyEnvVars, 1)
+				s.Require().Equal("my-root-key-secret", rootKeyEnvVars[0].ValueFrom.SecretKeyRef.Name)
+				s.Require().Equal("my-root-key", rootKeyEnvVars[0].ValueFrom.SecretKeyRef.Key)
+			} else {
+				s.Require().Empty(rootKeyEnvVars)
+			}
+
+			setValues["services.kas.root_key_secret.name"] = ""
+			setValues["services.kas.root_key_secret.key"] = ""
+			_, err := helm.RenderTemplateE(s.T(), options, s.chartPath, releaseName, []string{})
+			if test.keyManagementActive {
+				s.Require().ErrorContains(err, "When key management is enabled through services.kas.config.key_management or services.kas.config.preview.key_management, you must set both services.kas.root_key_secret.name and services.kas.root_key_secret.key")
+			} else {
+				s.Require().NoError(err)
+			}
+		})
+	}
 }
 
-func (s *PlatformChartTemplateSuite) Test_KeyManagement_Enabled_With_RootKeySecret_Expect_EnvVar_Set() {
-	releaseName := "key-management-with-secret"
-
+func (s *PlatformChartTemplateSuite) Test_KeyManagement_Default_Config_Uses_Stable_Field() {
+	releaseName := "key-management-default-config"
 	namespaceName := "opentdf-" + strings.ToLower(random.UniqueId())
 
 	options := &helm.Options{
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
-		SetValues: map[string]string{
-			"services.kas.config.preview.key_management": "true",
-			"services.kas.root_key_secret.name":          "my-root-key-secret",
-			"services.kas.root_key_secret.key":           "my-root-key",
-		},
 	}
 
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, releaseName, []string{"templates/deployment.yaml"})
-	var deployment appv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, releaseName, []string{"templates/config.yaml"})
+	var configMap corev1.ConfigMap
+	helm.UnmarshalK8SYaml(s.T(), output, &configMap)
 
-	envVarFound := false
-	for _, container := range deployment.Spec.Template.Spec.Containers {
-		for _, envVar := range container.Env {
-			if envVar.Name == "OPENTDF_SERVICES_KAS_ROOT_KEY" {
-				s.Require().Equal("my-root-key-secret", envVar.ValueFrom.SecretKeyRef.Name)
-				s.Require().Equal("my-root-key", envVar.ValueFrom.SecretKeyRef.Key)
-				envVarFound = true
-			}
-		}
-	}
-	s.Require().True(envVarFound)
+	var config map[string]interface{}
+	s.Require().NoError(yaml3.Unmarshal([]byte(configMap.Data["opentdf.yaml"]), &config))
+
+	services := config["services"].(map[string]interface{})
+	kas := services["kas"].(map[string]interface{})
+	s.Require().Equal(false, kas["key_management"])
+	preview := kas["preview"].(map[string]interface{})
+	s.Require().NotContains(preview, "key_management")
 }
 
 func (s *PlatformChartTemplateSuite) Test_Kas_PrivateKeySecret_Coalesce_NewValueTakesPrecedence() {


### PR DESCRIPTION
1.) Move `key_management` to stable in default values.yml
2.) Provide backwards compatibility for customers that are using the preview.key_management configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the platform Helm chart to version 0.25.1.
  - Key management is now configured through the stable top-level KAS configuration.

- **Bug Fixes**
  - Root-key settings and environment variables now work consistently with both stable and legacy key-management configurations.
  - Improved validation ensures required key-management secrets are provided.

- **Compatibility**
  - Existing configurations using the deprecated preview key-management setting remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->