### PR TITLE
fix(platform): render entityresolution config for claims and multi-strategy modes

### DIFF
--- a/charts/platform/README.md
+++ b/charts/platform/README.md
@@ -202,6 +202,7 @@ Download the [keycloak_data.yaml](https://raw.githubusercontent.com/opentdf/plat
 | services.authorization | object | `{}` |  |
 | services.entityresolution.clientid | string | `nil` | Client Id for Entity Resolver |
 | services.entityresolution.clientsecret | string | `nil` | Client Secret for Entity Resolver |
+| services.entityresolution.mode | string | `nil` | Entity resolution mode: keycloak (default), claims, or multi-strategy |
 | services.entityresolution.realm | string | `nil` | Entity Resolver Realm |
 | services.entityresolution.subgroups | bool | `false` | Subgroups |
 | services.entityresolution.url | string | `nil` | Identity Provider Entity Resolver |

--- a/charts/platform/templates/_config.tpl
+++ b/charts/platform/templates/_config.tpl
@@ -11,7 +11,8 @@ services:
 services:
   {{- if or (contains "all" .Values.mode ) (contains "core" .Values.mode ) }}
   {{- with (.Values.services).entityresolution }}
-  {{- if .url }}
+  {{- /* claims and multi-strategy modes have no url */}}
+  {{- if or .url .mode }}
   entityresolution:
   {{ . | toYaml | nindent 8 }}
   {{- end }}

--- a/charts/platform/values.yaml
+++ b/charts/platform/values.yaml
@@ -453,6 +453,8 @@ sdk_config:
 configTemplate: "platform.configurationEmpty.tpl"
 services:
   entityresolution:
+    # -- Entity resolution mode: keycloak (default), claims, or multi-strategy
+    mode:
     # -- Identity Provider Entity Resolver
     url:
     # -- Client Id for Entity Resolver

--- a/tests/chart_platform_config_blocks_test.go
+++ b/tests/chart_platform_config_blocks_test.go
@@ -14,7 +14,7 @@ import (
 // "fix(platform): suppress empty service blocks and fix auth.enabled bool rendering":
 //   - server.auth.enabled honors an explicit `false` (Helm's `default true` used to coerce it back to true)
 //   - server.cryptoProvider is omitted when standard.keys is empty
-//   - services.entityresolution is omitted unless a url is configured
+//   - services.entityresolution is omitted unless a url or mode is configured
 //   - services.authorization is omitted when left as the default empty map
 
 // renderOpentdfConfig renders templates/config.yaml and returns the parsed opentdf.yaml document.
@@ -114,11 +114,11 @@ func (s *PlatformChartTemplateSuite) Test_Mode_Core_Renders_Valid_Config_With_Se
 	s.Require().True(ok, "server.auth should still render for mode=core")
 }
 
-func (s *PlatformChartTemplateSuite) Test_EntityResolution_Absent_When_Url_Empty() {
+func (s *PlatformChartTemplateSuite) Test_EntityResolution_Absent_When_Unconfigured() {
 	config := s.renderOpentdfConfig(s.configOptions(nil, nil), "er-default")
 
 	_, ok := s.servicesBlock(config)["entityresolution"]
-	s.Require().False(ok, "services.entityresolution should be omitted when url is empty")
+	s.Require().False(ok, "services.entityresolution should be omitted when neither url nor mode is set")
 }
 
 func (s *PlatformChartTemplateSuite) Test_EntityResolution_Rendered_When_Url_Set() {
@@ -128,6 +128,33 @@ func (s *PlatformChartTemplateSuite) Test_EntityResolution_Rendered_When_Url_Set
 	er, ok := s.servicesBlock(config)["entityresolution"].(map[string]interface{})
 	s.Require().True(ok, "services.entityresolution should render when url is set")
 	s.Require().Equal("https://idp.example.com", er["url"], "entityresolution.url should match the configured value")
+}
+func (s *PlatformChartTemplateSuite) Test_EntityResolution_Rendered_For_MultiStrategy_Without_Url() {
+	options := s.configOptions(
+		map[string]string{
+			"services.entityresolution.mode":             "multi-strategy",
+			"services.entityresolution.failure_strategy": "fail-fast",
+		},
+		map[string]string{
+			"services.entityresolution.providers": `{"jwt_claims":{"type":"claims"}}`,
+		},
+	)
+	config := s.renderOpentdfConfig(options, "er-multi-strategy")
+
+	er, ok := s.servicesBlock(config)["entityresolution"].(map[string]interface{})
+	s.Require().True(ok, "services.entityresolution should render for multi-strategy mode without a url")
+	s.Require().Equal("multi-strategy", er["mode"])
+	s.Require().Equal("fail-fast", er["failure_strategy"])
+	s.Require().Contains(er, "providers", "multi-strategy providers should survive rendering")
+}
+
+func (s *PlatformChartTemplateSuite) Test_EntityResolution_Rendered_For_Claims_Mode_Without_Url() {
+	options := s.configOptions(map[string]string{"services.entityresolution.mode": "claims"}, nil)
+	config := s.renderOpentdfConfig(options, "er-claims")
+
+	er, ok := s.servicesBlock(config)["entityresolution"].(map[string]interface{})
+	s.Require().True(ok, "services.entityresolution should render for claims mode without a url")
+	s.Require().Equal("claims", er["mode"])
 }
 
 func (s *PlatformChartTemplateSuite) Test_Authorization_Absent_When_Default_Empty() {

--- a/tests/chart_platform_config_blocks_test.go
+++ b/tests/chart_platform_config_blocks_test.go
@@ -145,7 +145,11 @@ func (s *PlatformChartTemplateSuite) Test_EntityResolution_Rendered_For_MultiStr
 	s.Require().True(ok, "services.entityresolution should render for multi-strategy mode without a url")
 	s.Require().Equal("multi-strategy", er["mode"])
 	s.Require().Equal("fail-fast", er["failure_strategy"])
-	s.Require().Contains(er, "providers", "multi-strategy providers should survive rendering")
+	s.Require().Equal(
+		map[string]interface{}{"jwt_claims": map[string]interface{}{"type": "claims"}},
+		er["providers"],
+		"multi-strategy providers should survive rendering intact",
+	)
 }
 
 func (s *PlatformChartTemplateSuite) Test_EntityResolution_Rendered_For_Claims_Mode_Without_Url() {


### PR DESCRIPTION
## Summary

The `entityresolution` config block was guarded on `.url` alone, which is a Keycloak-only field. Deployments using `mode: claims` or `mode: multi-strategy` had their entire ERS config silently dropped from the ConfigMap, so the platform fell through to the default Keycloak ERS with an empty url and failed at runtime with `unsupported protocol scheme ""` on the first entitlements call.

Guard on `or .url .mode` instead.

## Changes

- `_config.tpl`: guard the block on `or .url .mode`
- `values.yaml` / `README.md`: document the `mode` key (unset by default, so a fresh install still renders no block)
- tests: regression coverage for multi-strategy and claims rendering without a url

## Notes

The chart still emits its nil Keycloak defaults (`url: null`, `clientid: null`, …) alongside multi-strategy config. This is inert — the platform's `ERSConfig` decodes only `mode` and `cache_expiration`, then switches; the claims and multi-strategy branches never reach `keycloak.RegisterKeycloakERS`. Matches the config shape already validated in `qa-ers-test`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable entity resolution modes: `keycloak` (default), `claims`, and `multi-strategy`.
  - Claims and multi-strategy configurations can now be used without specifying a service URL.
  - Multi-strategy configuration supports failure strategy and provider settings.

- **Documentation**
  - Updated Helm chart values documentation with the available entity resolution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->